### PR TITLE
Add test suite and configure developer tooling to use pytest

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,5 +26,7 @@ jobs:
         run: uv run ruff check
       - name: Format with Ruff
         run: uv run ruff format
+      - name: Test with pytest
+        run: uv run pytest
       - name: Check with pre-commit
         run: uv run pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
         args: ["--fix=lf"]
+      - id: name-tests-test
+        args: [--pytest-test-first]
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
     rev: 0.8.0
     hooks:
       - id: uv-lock
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: pytest-check
+        types: [python]
+        entry: uv run pytest
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ repos:
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.21
+    rev: 0.8.0
     hooks:
       - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ requires-python = ">=3.13"
 dependencies = []
 
 [dependency-groups]
-dev = ["pre-commit>=4.2.0", "ruff>=0.12.3"]
+dev = [
+    "pre-commit>=4.2.0",
+ "pytest>=8.4.1",
+ "ruff>=0.12.3",
+]
 docs = ["mkdocs-bibtex>=4.4.0", "mkdocs-material>=9.6.15"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,7 @@ requires-python = ">=3.13"
 dependencies = []
 
 [dependency-groups]
-dev = [
-    "pre-commit>=4.2.0",
- "pytest>=8.4.1",
- "ruff>=0.12.3",
-]
+dev = ["pre-commit>=4.2.0", "pytest>=8.4.1", "ruff>=0.12.3"]
 docs = ["mkdocs-bibtex>=4.4.0", "mkdocs-material>=9.6.15"]
 
 [tool.ruff]

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,0 +1,30 @@
+import pytest
+
+from aviation.fleet import passengers_per_day, required_global_fleet
+
+
+@pytest.mark.parametrize(
+    ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
+    (
+        (365_000_000.0, 365.0, 1_000_000.0),
+        (732_000_000.0, 366.0, 2_000_000.0),
+    ),
+)
+def test_passengers_per_day(passengers_per_year, days_per_year, expected_passengers_per_day):
+    assert passengers_per_day(passengers_per_year, days_per_year) == expected_passengers_per_day
+
+
+@pytest.mark.parametrize("days_per_year", (365.0, 365.25, 366.0))
+def test_required_global_fleet(days_per_year):
+    passengers_per_year = 5_000_000_000.0
+    seats_per_aircraft = 200.0
+    flights_per_aircraft_per_day = 3.0
+
+    expected_required_global_fleet = 25_000.0
+
+    result = required_global_fleet(
+        passengers_per_day(passengers_per_year, days_per_year),
+        seats_per_aircraft,
+        flights_per_aircraft_per_day,
+    )
+    assert result == pytest.approx(expected_required_global_fleet, abs=5_000.0)

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ source = { editable = "." }
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 docs = [
@@ -22,6 +23,7 @@ docs = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.3" },
 ]
 docs = [
@@ -159,6 +161,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -361,6 +372,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -418,6 +438,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/88/26e650d053df5f3874aa3c05901a14166ce3271f58bfe114fd776987efbd/pypandoc-1.15.tar.gz", hash = "sha256:ea25beebe712ae41d63f7410c08741a3cab0e420f6703f95bc9b3a749192ce13", size = 32940, upload-time = "2025-01-08T17:39:58.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/06/0763e0ccc81754d3eadb21b2cb86cf21bdedc9b52698c2ad6785db7f0a4e/pypandoc-1.15-py3-none-any.whl", hash = "sha256:4ededcc76c8770f27aaca6dff47724578428eca84212a31479403a9731fc2b16", size = 21321, upload-time = "2025-01-08T17:39:09.928Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds the beginning of a test suite that's run using [pytest](https://docs.pytest.org/en/stable/). The pre-commit hooks and `check` workflow are also updated so that the tests are run automatically.