### PR TITLE
Configure static type checking using mypy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,6 +29,8 @@ jobs:
         run: uv run ruff check
       - name: Format with Ruff
         run: uv run ruff format
+      - name: Static type check with mypy
+        run: uv run mypy .
       - name: Test with pytest
         run: uv run pytest
       - name: Check with pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
       - id: uv-lock
   - repo: local
     hooks:
+      - id: mypy-check
+        name: mypy-check
+        types: [python]
+        entry: uv run mypy .
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: pytest-check
         name: pytest-check
         types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,34 @@ line-length = 100
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["B", "D", "E", "F", "I", "N", "SIM", "T", "UP"]
-ignore = ["E501"]
+select = ["ALL"]
+ignore = [
+    "ANN1",
+    "COM812",
+    "COM819",
+    "D206",
+    "D300",
+    "E111",
+    "E114",
+    "E117",
+    "E501",
+    "ISC001",
+    "ISC002",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
+]
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+parametrize-values-type = "tuple"
 
 [tool.ruff.lint.per-file-ignores]
-"analysis/*" = ["T201"]
-"tests/*" = ["D1"]
+"analysis/*" = ["INP001", "T201"]
+"tests/*" = ["D1", "INP001", "S101"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,17 @@ requires-python = ">=3.13"
 dependencies = []
 
 [dependency-groups]
-dev = ["pre-commit>=4.2.0", "pytest>=8.4.1", "ruff>=0.12.3"]
+dev = ["mypy>=1.17.0", "pre-commit>=4.2.0", "pytest>=8.4.1", "ruff>=0.12.3"]
 docs = [
     "mkdocs-bibtex>=4.4.0",
     "mkdocs-material>=9.6.15",
     "mkdocs-prebuild>=0.5.0",
     "mkdocstrings[python]>=0.29.1",
 ]
+
+[tool.mypy]
+mypy_path = "src"
+strict = true
 
 [tool.ruff]
 line-length = 100

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -1,25 +1,27 @@
 """Modelling of the global fleet based on average passenger and aircraft data."""
 
 
-def passengers_per_day(passengers_per_year, days_per_year):
+def passengers_per_day(passengers_per_year: float, days_per_year: float) -> float:
     """The number of passengers per day globally.
 
     Args:
-        passengers_per_year (float): The number of passengers flying per year globally.
-        days_per_year (float): The number of days in the modelled year.
+        passengers_per_year: The number of passengers flying per year globally.
+        days_per_year: The number of days in the modelled year.
 
     """
     return passengers_per_year / days_per_year
 
 
-def required_global_fleet(passengers_per_day, seats_per_aircraft, flights_per_aircraft_per_day):
+def required_global_fleet(
+    passengers_per_day: float, seats_per_aircraft: float, flights_per_aircraft_per_day: float
+) -> float:
     """The size of the required global fleet.
 
     Args:
-        passengers_per_day (float): The number of passengers flying per day globally.
-        seats_per_aircraft (float): The average number of seats on a commercial aircraft.
-        flights_per_aircraft_per_day (float): The average number of flights a commercial aircraft
-            makes on average per day.
+        passengers_per_day: The number of passengers flying per day globally.
+        seats_per_aircraft: The average number of seats on a commercial aircraft.
+        flights_per_aircraft_per_day: The average number of flights a commercial aircraft makes on
+            average per day.
 
     """
     return passengers_per_day / (seats_per_aircraft * flights_per_aircraft_per_day)

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -10,12 +10,14 @@ from aviation.fleet import passengers_per_day, required_global_fleet
         (732_000_000.0, 366.0, 2_000_000.0),
     ),
 )
-def test_passengers_per_day(passengers_per_year, days_per_year, expected_passengers_per_day):
+def test_passengers_per_day(
+    passengers_per_year: float, days_per_year: float, expected_passengers_per_day: float
+) -> None:
     assert passengers_per_day(passengers_per_year, days_per_year) == expected_passengers_per_day
 
 
 @pytest.mark.parametrize("days_per_year", (365.0, 365.25, 366.0))
-def test_required_global_fleet(days_per_year):
+def test_required_global_fleet(days_per_year: float) -> None:
     passengers_per_year = 5_000_000_000.0
     seats_per_aircraft = 200.0
     flights_per_aircraft_per_day = 3.0

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -24,6 +25,7 @@ docs = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.17.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.3" },
@@ -406,6 +408,35 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.17.0"
+source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e3/034322d5a779685218ed69286c32faa505247f1f096251ef66c8fd203b08/mypy-1.17.0.tar.gz", hash = "sha256:e5d7ccc08ba089c06e2f5629c660388ef1fee708444f1dee0b9203fa031dee03", size = 3352114, upload-time = "2025-07-14T20:34:30.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/5f8ab461369b9e62157072156935cec9d272196556bdc7c2ff5f4c7c0f9b/mypy-1.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c41aa59211e49d717d92b3bb1238c06d387c9325d3122085113c79118bebb06", size = 11070019, upload-time = "2025-07-14T20:32:07.99Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/c49c9e5a2ac0badcc54beb24e774d2499748302c9568f7f09e8730e953fa/mypy-1.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0e69db1fb65b3114f98c753e3930a00514f5b68794ba80590eb02090d54a5d4a", size = 10114457, upload-time = "2025-07-14T20:33:47.285Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/fb3f9c939ad9beed3e328008b3fb90b20fda2cddc0f7e4c20dbefefc3b33/mypy-1.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03ba330b76710f83d6ac500053f7727270b6b8553b0423348ffb3af6f2f7b889", size = 11857838, upload-time = "2025-07-14T20:33:14.462Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/85607ab5137d65e4f54d9797b77d5a038ef34f714929cf8ad30b03f628df/mypy-1.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:037bc0f0b124ce46bfde955c647f3e395c6174476a968c0f22c95a8d2f589bba", size = 12731358, upload-time = "2025-07-14T20:32:25.579Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d0/341dbbfb35ce53d01f8f2969facbb66486cee9804048bf6c01b048127501/mypy-1.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c38876106cb6132259683632b287238858bd58de267d80defb6f418e9ee50658", size = 12917480, upload-time = "2025-07-14T20:34:21.868Z" },
+    { url = "https://files.pythonhosted.org/packages/64/63/70c8b7dbfc520089ac48d01367a97e8acd734f65bd07813081f508a8c94c/mypy-1.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:d30ba01c0f151998f367506fab31c2ac4527e6a7b2690107c7a7f9e3cb419a9c", size = 9589666, upload-time = "2025-07-14T20:34:16.841Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/fc/ee058cc4316f219078464555873e99d170bde1d9569abd833300dbeb484a/mypy-1.17.0-py3-none-any.whl", hash = "sha256:15d9d0018237ab058e5de3d8fce61b6fa72cc59cc78fd91f1b474bce12abf496", size = 2283195, upload-time = "2025-07-14T20:31:54.753Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
@@ -655,6 +686,15 @@ source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/
 sdist = { url = "https://files.pythonhosted.org/packages/59/73/0fb0b9fe4964b45b2a06ed41b60c352752626db46aa0fb70a49a9e283a75/types-colorama-0.4.15.20240311.tar.gz", hash = "sha256:a28e7f98d17d2b14fb9565d32388e419f4108f557a7d939a66319969b2b99c7a", size = 5608, upload-time = "2024-03-11T02:15:51.557Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/83/6944b4fa01efb2e63ac62b791a8ddf0fee358f93be9f64b8f152648ad9d3/types_colorama-0.4.15.20240311-py3-none-any.whl", hash = "sha256:6391de60ddc0db3f147e31ecb230006a6823e81e380862ffca1e4695c13a0b8e", size = 5840, upload-time = "2024-03-11T02:15:50.43Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR configures [mypy](https://mypy.readthedocs.io/en/stable/) to conduct static type checking of code ahead of runtime using [PEP 484](https://peps.python.org/pep-0484/) type hints.