### PR TITLE
Add `SystemsModel` class

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,9 +1,14 @@
 """Analysis to determine the number of passengers per day globally."""
 
 import aviation
+from aviation import _engine as engine
 
-days_per_year = 365.0
+days_per_year = 365.25
 passengers_per_year = 5_000_000_000.0
 
-passengers_per_day = aviation.passengers_per_day(passengers_per_year, days_per_year)
+inputs = {"days_per_year": days_per_year, "passengers_per_year": passengers_per_year}
+output = "passengers_per_day"
+
+systems_model = engine.SystemsModel(aviation.transforms)
+passengers_per_day = systems_model.evaluate(inputs, output)
 print(f"{passengers_per_day=}")

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,14 +1,21 @@
 """Analysis to determine the required size of the global fleet."""
 
 import aviation
+from aviation import _engine as engine
 
-days_per_year = 365.0
+days_per_year = 365.25
 passengers_per_year = 5_000_000_000.0
-seats_per_aircraft = 150.0
-flights_per_aircraft_per_day = 2.0
+seats_per_aircraft = 200.0
+flights_per_aircraft_per_day = 3.0
 
-passengers_per_day = aviation.passengers_per_day(passengers_per_year, days_per_year)
-required_global_fleet = aviation.required_global_fleet(
-    passengers_per_day, seats_per_aircraft, flights_per_aircraft_per_day
-)
+inputs = {
+    "passengers_per_year": passengers_per_year,
+    "days_per_year": days_per_year,
+    "seats_per_aircraft": seats_per_aircraft,
+    "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
+}
+output = "required_global_fleet"
+
+systems_model = engine.SystemsModel(aviation.transforms)
+required_global_fleet = systems_model.evaluate(inputs, output)
 print(f"{required_global_fleet=}")

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -6,6 +6,8 @@ Modules:
 
 """
 
-__all__ = ("passengers_per_day", "required_global_fleet")
+__all__ = ("passengers_per_day", "required_global_fleet", "transforms")
 
 from aviation.fleet import passengers_per_day, required_global_fleet
+
+transforms = (passengers_per_day, required_global_fleet)

--- a/src/aviation/_engine.py
+++ b/src/aviation/_engine.py
@@ -1,0 +1,40 @@
+"""Evaluate systems models of transforms."""
+
+import collections.abc
+import typing
+
+from aviation._model import Transform
+
+
+class SystemsModel:
+    """A systems model defined by a sequence of transforms."""
+
+    def __init__(self, transforms: collections.abc.Sequence[Transform[typing.Any, ...]]) -> None:
+        """Initialize the system model from a sequence of transforms."""
+        self.transforms = set(transforms)
+
+    def evaluate(self, inputs: dict[str, typing.Any], output: str) -> typing.Any:  # noqa: ANN401
+        """Calculate the value returned by a transform."""
+        # If the requested `output` has already been supplied as an input then this can just be
+        # returned directly without any need for computation.
+        if output in inputs:
+            return inputs[output]
+
+        # The requested `output` isn't in `inputs` so it must be the name of a transform in
+        # `self.transforms`. If it's not found in `self.transforms` then there must be an error.
+        for transform in self.transforms:
+            if transform.name == output:
+                break
+        else:
+            message = f"No transform with name `{output}`."
+            raise ValueError(message)
+
+        # To evaluate the `transform`, argument for all of its parameters are required. If a
+        # parameter's name can't be found in `inputs` make a recursive call to
+        for parameter in transform.parameters:
+            if parameter not in inputs:
+                inputs[parameter] = self.evaluate(inputs, parameter)
+
+        # Eaaluate and return the `transform` associated with the passed `output`.
+        arguments = {parameter: inputs[parameter] for parameter in transform.parameters}
+        return transform(**arguments)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,51 @@
+import typing
+
+import pytest
+
+import aviation
+from aviation import _engine as engine
+
+
+@pytest.fixture
+def systems_model() -> engine.SystemsModel:
+    return engine.SystemsModel(aviation.transforms)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "output", "expected"),
+    (
+        ({"passengers_per_year": 5_000_000_000.0}, "passengers_per_year", 5_000_000_000.0),
+        ({"required_global_fleet": 25_000.0}, "required_global_fleet", 25_000.0),
+        (
+            {"days_per_year": 365.25, "passengers_per_year": 5_000_000_000.0},
+            "passengers_per_day",
+            13_689_254.0,
+        ),
+        (
+            {
+                "passengers_per_day": 13_689_254.0,
+                "seats_per_aircraft": 200.0,
+                "flights_per_aircraft_per_day": 3.0,
+            },
+            "required_global_fleet",
+            22_815.0,
+        ),
+        (
+            {
+                "days_per_year": 365.25,
+                "passengers_per_year": 5_000_000_000.0,
+                "seats_per_aircraft": 200.0,
+                "flights_per_aircraft_per_day": 3.0,
+            },
+            "required_global_fleet",
+            22_815.0,
+        ),
+    ),
+)
+def test_systems_model_evaluate(
+    systems_model: engine.SystemsModel,
+    inputs: dict[str, typing.Any],
+    output: str,
+    expected: typing.Any,  # noqa: ANN401
+) -> None:
+    assert systems_model.evaluate(inputs, output) == pytest.approx(expected, abs=1.0)


### PR DESCRIPTION
This PR adds the `SystemsModel` class, like the one from [camia-engine](https://github.com/aviation-impact-accelerator/camia-engine), which can be used to define a systems model from transforms and used to evaluate a specific transform as an output from a collection of known inputs.